### PR TITLE
fixed logging setup in DependencyContainerFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Below are instructions on how to get the dev environment up and running.
 
-The commands should work in Linux or Windows under git bash -- and if they do not, it should be straightforward for you
+The commands were tested under Windows git bash. It should be straightforward for you
 to adjust as necessary for your environment.
 
 Note: Docker compose is required.
@@ -12,10 +12,10 @@ Note: Docker compose is required.
 To get started:
 
 1. copy `.env.template` to `.env` and update any values, then
-2. run `init.sh` to download WordPress and stage the plugin files. Finally,
+2. run `init.sh` to download WordPress, run docker install, and stage some files. Finally,
 3. execute `docker compose up`.
 
-## Dev-Utils
+## Dev-Utils Setup
 
 The example commands in this documentation expect certain `phar` files to exist in `dev-utils`.
 
@@ -46,6 +46,7 @@ php jds-demo-plugin/tasks/extract-twig-text.php
 ## Static Analysis
 
 ```bash
+# PHPStan
 ./dev-utils/phpstan/vendor/bin/phpstan analyse --memory-limit 1G
 
 # Psalm

--- a/build.sh
+++ b/build.sh
@@ -4,5 +4,6 @@ rm -r build
 
 ./dev-utils/composer.phar --working-dir=jds-demo-plugin install --no-dev
 ./dev-utils/scoper/vendor/bin/php-scoper add-prefix --force -v
+mkdir build/logs
 ./dev-utils/composer.phar --working-dir=build dump-autoload --classmap-authoritative
 ./dev-utils/composer.phar --working-dir=jds-demo-plugin install

--- a/jds-demo-plugin/src/Services/DependencyContainerFactory.php
+++ b/jds-demo-plugin/src/Services/DependencyContainerFactory.php
@@ -51,6 +51,9 @@ class DependencyContainerFactory
             'paths.pluginRoot' => $rootPluginPath,
             'paths.loggingFolder' => $rootPluginPath . self::LOG_PATH_PARTIAL . DIRECTORY_SEPARATOR,
             'keys.translationDomain' => Plugin::TRANSLATION_DOMAIN,
+            'keys.environment' => $env,
+            'keys.productionEnvironment' => self::ENV_PROD,
+            'keys.testEnvironment' => self::ENV_TEST,
             ConfigFactory::class => function (ContainerInterface $c) {
                 /** @var FileSystem $fileSystem */
                 $fileSystem = $c->get(FileSystem::class);
@@ -74,9 +77,11 @@ class DependencyContainerFactory
 
                 return new FilesystemLoader($templateConfig->templateRootPath);
             },
-            LoggerInterface::class => function (ContainerInterface $c) use ($env) {
+            LoggerInterface::class => function (ContainerInterface $c) {
+                $env = (string)$c->get('keys.environment');
+                $testEnvValue = (string)$c->get('keys.testEnvironment');
                 $logger = new Logger('jds-demo-plugin::' . $env);
-                $level = $env === self::ENV_TEST
+                $level = $env === $testEnvValue
                     ? Logger::INFO
                     : Logger::NOTICE;
                 $logFolder = (string)$c->get('paths.loggingFolder');

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -20,7 +20,9 @@ return [
         Finder::create()->files()->in(['./jds-demo-plugin/src',
             './jds-demo-plugin/tasks',
             './jds-demo-plugin/languages',
-            './jds-demo-plugin/templates']),
+            './jds-demo-plugin/templates',
+            './jds-demo-plugin/logs'
+            ])->notName(['*.log']),
         Finder::create()->files()->in('./jds-demo-plugin')->name(['jsd-demo-plugin.php']),
         Finder::create()
             ->files()


### PR DESCRIPTION
- callback used to create logging instance broke the rules:
  - no `use()` values
  - no references to `self::`
- updated `build.sh` to create a `build/logs` directory after
  the scoping tasks complete
- a few unnecessary wording tweaks to README