### PR TITLE
fixed .pot file generation

### DIFF
--- a/jds-demo-plugin/languages/jds-demo-plugin.pot
+++ b/jds-demo-plugin/languages/jds-demo-plugin.pot
@@ -7,11 +7,25 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-08-26T19:49:57+00:00\n"
+"POT-Creation-Date: 2021-10-04T03:25:40+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 
-#: Plugin.php:20
-#: Plugin.php:21
+#: jds-demo-plugin-options.php:2
+msgid "Demo \"Plugin\" Page"
+msgstr ""
+
+#. translators: casual greeting
+#: jds-demo-plugin-options.php:4
+msgid "Hello, %s!"
+msgstr ""
+
+#. translators: casual greeting
+#: jds-demo-plugin-options.php:5
+msgid "Hit refresh to view another name (selected at random)."
+msgstr ""
+
+#: Plugin.php:89
+#: Plugin.php:90
 msgid "JDS Demo Plugin"
 msgstr ""

--- a/refresh-pot.sh
+++ b/refresh-pot.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR=$(pwd)
 
 printf "executing within %s \n\n" "$SCRIPT_DIR"
 
-php ./dev-utils/wp-cli.phar i18n make-pot ./jds-demo-plugin/src --ignore-domain ./jds-demo-plugin/languages/jds-demo-plugin.pot --include=./jds-demo-plugin/cache/gettext/*.php --exclude=./jds-demo-plugin/tests/* --merge
+php ./dev-utils/wp-cli.phar i18n make-pot ./jds-demo-plugin/cache/gettext jds-demo-plugin/cache/gettext/templates.pot --ignore-domain
+php ./dev-utils/wp-cli.phar i18n make-pot ./jds-demo-plugin/src jds-demo-plugin/languages/jds-demo-plugin.pot --merge=jds-demo-plugin/cache/gettext/templates.pot --ignore-domain
 
 printf "\njds-demo-plugin/languages/jds-demo-plugin.pot updated"


### PR DESCRIPTION
After some experimentation, `--include` and `--exclude` seem to not be
working as documented
(https://developer.wordpress.org/cli/commands/i18n/make-pot/).

The changed code generates a twig template .pot file separately, and
then that is merged into the plugin source .pot file.

Additional tweaks to the whole house of cards may be required after
i10n is actually attempted.